### PR TITLE
複数ページ対応機能を実装

### DIFF
--- a/lib/features/board/providers/board_provider.dart
+++ b/lib/features/board/providers/board_provider.dart
@@ -23,29 +23,41 @@ enum AppMode {
 // ── ボードの状態 ────────────────────────────────────────────
 @immutable
 class BoardState {
-  final PageData? currentPage;
-  final List<String> selectedObjectIds;  // 選択中オブジェクトID
+  final List<PageData> pages;            // 全ページのリスト
+  final int currentPageIndex;            // 現在表示中のページインデックス
+  final List<String> selectedObjectIds; // 選択中オブジェクトID
   final AppMode mode;
   final bool canUndo;
   final bool canRedo;
 
   const BoardState({
-    this.currentPage,
+    this.pages = const [],
+    this.currentPageIndex = 0,
     this.selectedObjectIds = const [],
     this.mode = AppMode.teacherEdit,
     this.canUndo = false,
     this.canRedo = false,
   });
 
+  /// 現在表示中のページを取得
+  PageData? get currentPage {
+    if (pages.isEmpty || currentPageIndex < 0 || currentPageIndex >= pages.length) {
+      return null;
+    }
+    return pages[currentPageIndex];
+  }
+
   BoardState copyWith({
-    PageData? currentPage,
+    List<PageData>? pages,
+    int? currentPageIndex,
     List<String>? selectedObjectIds,
     AppMode? mode,
     bool? canUndo,
     bool? canRedo,
   }) =>
       BoardState(
-        currentPage: currentPage ?? this.currentPage,
+        pages: pages ?? this.pages,
+        currentPageIndex: currentPageIndex ?? this.currentPageIndex,
         selectedObjectIds: selectedObjectIds ?? this.selectedObjectIds,
         mode: mode ?? this.mode,
         canUndo: canUndo ?? this.canUndo,
@@ -65,7 +77,8 @@ class BoardNotifier extends StateNotifier<BoardState> {
     final page = PageData.fromMunJson(munJson);
     _undoManager.reset();
     state = state.copyWith(
-      currentPage: page,
+      pages: [page],
+      currentPageIndex: 0,
       selectedObjectIds: [],
       canUndo: false,
       canRedo: false,
@@ -88,8 +101,13 @@ class BoardNotifier extends StateNotifier<BoardState> {
       toX: newX, toY: newY,
     );
     final newPage = _undoManager.execute(cmd, page);
+    
+    // 現在のページを新しいページに置き換え
+    final newPages = List<PageData>.from(state.pages);
+    newPages[state.currentPageIndex] = newPage;
+    
     state = state.copyWith(
-      currentPage: newPage,
+      pages: newPages,
       canUndo: _undoManager.canUndo,
       canRedo: _undoManager.canRedo,
     );
@@ -101,8 +119,11 @@ class BoardNotifier extends StateNotifier<BoardState> {
     if (page == null || !_undoManager.canUndo) return;
     final newPage = _undoManager.undo(page);
     if (newPage != null) {
+      final newPages = List<PageData>.from(state.pages);
+      newPages[state.currentPageIndex] = newPage;
+      
       state = state.copyWith(
-        currentPage: newPage,
+        pages: newPages,
         canUndo: _undoManager.canUndo,
         canRedo: _undoManager.canRedo,
       );
@@ -115,8 +136,11 @@ class BoardNotifier extends StateNotifier<BoardState> {
     if (page == null || !_undoManager.canRedo) return;
     final newPage = _undoManager.redo(page);
     if (newPage != null) {
+      final newPages = List<PageData>.from(state.pages);
+      newPages[state.currentPageIndex] = newPage;
+      
       state = state.copyWith(
-        currentPage: newPage,
+        pages: newPages,
         canUndo: _undoManager.canUndo,
         canRedo: _undoManager.canRedo,
       );
@@ -146,8 +170,12 @@ class BoardNotifier extends StateNotifier<BoardState> {
       object: obj,
     );
     final newPage = _undoManager.execute(cmd, page);
+    
+    final newPages = List<PageData>.from(state.pages);
+    newPages[state.currentPageIndex] = newPage;
+    
     state = state.copyWith(
-      currentPage: newPage,
+      pages: newPages,
       canUndo: _undoManager.canUndo,
       canRedo: _undoManager.canRedo,
     );
@@ -159,10 +187,11 @@ class BoardNotifier extends StateNotifier<BoardState> {
       final pages = await _materialsService.getPages(materialId);
       
       if (pages.isNotEmpty) {
-        // 最初のページを表示
+        // 全ページを読み込み、最初のページを表示
         _undoManager.reset();
         state = state.copyWith(
-          currentPage: pages.first,
+          pages: pages,
+          currentPageIndex: 0,
           selectedObjectIds: [],
           canUndo: false,
           canRedo: false,
@@ -181,12 +210,14 @@ class BoardNotifier extends StateNotifier<BoardState> {
   /// 空のページを初期化する（新規教材用）
   void initEmptyPage(String title) {
     _undoManager.reset();
+    final emptyPage = PageData(
+      id: _generateUuid(),
+      pageTitle: 'ページ 1',
+      objectsData: const [],
+    );
     state = state.copyWith(
-      currentPage: PageData(
-        id: _generateUuid(),
-        pageTitle: '',  // ページタイトルは空文字、教材タイトルはAppBarで表示
-        objectsData: const [],
-      ),
+      pages: [emptyPage],
+      currentPageIndex: 0,
       selectedObjectIds: [],
       canUndo: false,
       canRedo: false,
@@ -197,6 +228,62 @@ class BoardNotifier extends StateNotifier<BoardState> {
   void clearPage() {
     _undoManager.reset();
     state = const BoardState();
+  }
+
+  /// ページを切り替える
+  void setCurrentPageIndex(int index) {
+    if (index >= 0 && index < state.pages.length) {
+      _undoManager.reset(); // ページ切り替え時はUndoをリセット
+      state = state.copyWith(
+        currentPageIndex: index,
+        selectedObjectIds: [],
+        canUndo: false,
+        canRedo: false,
+      );
+    }
+  }
+
+  /// 新しいページを追加
+  void addPage() {
+    final newPage = PageData(
+      id: _generateUuid(),
+      pageTitle: 'ページ ${state.pages.length + 1}',
+      objectsData: const [],
+    );
+    final newPages = List<PageData>.from(state.pages);
+    newPages.add(newPage);
+    
+    state = state.copyWith(
+      pages: newPages,
+      currentPageIndex: newPages.length - 1, // 新しいページに切り替え
+      selectedObjectIds: [],
+    );
+  }
+
+  /// ページを削除
+  void deletePage(int index) {
+    if (state.pages.length <= 1) return; // 最低1ページは残す
+    if (index < 0 || index >= state.pages.length) return;
+
+    final newPages = List<PageData>.from(state.pages);
+    newPages.removeAt(index);
+    
+    // 現在のページインデックスを調整
+    int newIndex = state.currentPageIndex;
+    if (index <= state.currentPageIndex && state.currentPageIndex > 0) {
+      newIndex = state.currentPageIndex - 1;
+    } else if (state.currentPageIndex >= newPages.length) {
+      newIndex = newPages.length - 1;
+    }
+
+    _undoManager.reset();
+    state = state.copyWith(
+      pages: newPages,
+      currentPageIndex: newIndex,
+      selectedObjectIds: [],
+      canUndo: false,
+      canRedo: false,
+    );
   }
 
   String _generateUuid() => const Uuid().v4();

--- a/lib/features/board/screens/board_screen.dart
+++ b/lib/features/board/screens/board_screen.dart
@@ -122,39 +122,49 @@ class _BoardScreenState extends ConsumerState<BoardScreen> {
       ),
       body: page == null
           ? const Center(child: CircularProgressIndicator())
-          : BoardCanvas(
-              page: page,
-              mode: mode,
-              onObjectMoved: (id, x, y) {
-                ref
-                    .read(boardProvider(_materialId).notifier)
-                    .moveObject(id, x, y);
-              },
-              onObjectSelected: (id) {
-                ref
-                    .read(boardProvider(_materialId).notifier)
-                    .selectObject(id);
-              },
+          : Column(
+              children: [
+                // ページタブバー
+                if (mode == AppMode.teacherEdit) _buildPageTabBar(),
+                // ボードキャンバス
+                Expanded(
+                  child: BoardCanvas(
+                    page: page,
+                    mode: mode,
+                    onObjectMoved: (id, x, y) {
+                      ref
+                          .read(boardProvider(_materialId).notifier)
+                          .moveObject(id, x, y);
+                    },
+                    onObjectSelected: (id) {
+                      ref
+                          .read(boardProvider(_materialId).notifier)
+                          .selectObject(id);
+                    },
+                  ),
+                ),
+              ],
             ),
       floatingActionButton: mode == AppMode.teacherEdit
           ? FloatingActionButton(
               child: const Icon(Icons.add),
               onPressed: () => _showAddObjectMenu(),
+              tooltip: 'オブジェクト追加',
             )
           : null,
     );
   }
 
   Future<void> _save(String materialId) async {
-    final page = ref.read(boardProvider(_materialId)).currentPage;
-    if (page == null) return;
+    final boardState = ref.read(boardProvider(_materialId));
+    final pages = boardState.pages;
+    if (pages.isEmpty) return;
 
     try {
-      await ref.read(materialsServiceProvider).savePage(
-            materialId: materialId,
-            pageOrder: 0,
-            pageData: page,
-          );
+      // 全ページを保存
+      final service = ref.read(materialsServiceProvider);
+      await service.saveAllPages(materialId: materialId, pages: pages);
+      
       if (mounted) {
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
@@ -215,6 +225,89 @@ class _BoardScreenState extends ConsumerState<BoardScreen> {
         );
         ref.read(boardProvider(_materialId).notifier).addObject(newObj);
       },
+    );
+  }
+
+  Widget _buildPageTabBar() {
+    final boardState = ref.watch(boardProvider(_materialId));
+    final pages = boardState.pages;
+    final currentIndex = boardState.currentPageIndex;
+
+    return Container(
+      height: 50,
+      color: Theme.of(context).primaryColor.withOpacity(0.1),
+      child: Row(
+        children: [
+          // ページタブ
+          Expanded(
+            child: ListView.builder(
+              scrollDirection: Axis.horizontal,
+              itemCount: pages.length,
+              itemBuilder: (context, index) {
+                final isSelected = index == currentIndex;
+                return GestureDetector(
+                  onTap: () {
+                    ref.read(boardProvider(_materialId).notifier)
+                        .setCurrentPageIndex(index);
+                  },
+                  child: Container(
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 16, vertical: 8),
+                    margin: const EdgeInsets.all(4),
+                    decoration: BoxDecoration(
+                      color: isSelected 
+                          ? Theme.of(context).primaryColor
+                          : Colors.transparent,
+                      borderRadius: BorderRadius.circular(8),
+                      border: Border.all(
+                        color: Theme.of(context).primaryColor,
+                      ),
+                    ),
+                    child: Row(
+                      mainAxisSize: MainAxisSize.min,
+                      children: [
+                        Text(
+                          pages[index].pageTitle.isEmpty
+                              ? 'ページ ${index + 1}'
+                              : pages[index].pageTitle,
+                          style: TextStyle(
+                            color: isSelected ? Colors.white : null,
+                            fontWeight: isSelected 
+                                ? FontWeight.bold 
+                                : FontWeight.normal,
+                          ),
+                        ),
+                        if (pages.length > 1) ..[
+                          const SizedBox(width: 8),
+                          GestureDetector(
+                            onTap: () {
+                              ref.read(boardProvider(_materialId).notifier)
+                                  .deletePage(index);
+                            },
+                            child: Icon(
+                              Icons.close,
+                              size: 16,
+                              color: isSelected ? Colors.white : null,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                  ),
+                );
+              },
+            ),
+          ),
+          // ページ追加ボタン
+          IconButton(
+            icon: const Icon(Icons.add),
+            onPressed: () {
+              ref.read(boardProvider(_materialId).notifier).addPage();
+            },
+            tooltip: 'ページ追加',
+          ),
+        ],
+      ),
     );
   }
 }

--- a/lib/features/materials/services/materials_service.dart
+++ b/lib/features/materials/services/materials_service.dart
@@ -73,4 +73,33 @@ class MaterialsService {
       return PageData.fromJson(objects);
     }).toList();
   }
+
+  /// 全ページを一括保存（既存ページは削除してから保存）
+  Future<void> saveAllPages({
+    required String materialId,
+    required List<PageData> pages,
+  }) async {
+    // 既存のページをすべて削除
+    await _client
+        .from('pages')
+        .delete()
+        .eq('material_id', materialId);
+
+    // 新しいページをすべて挿入
+    final insertData = pages.asMap().entries.map((entry) {
+      final index = entry.key;
+      final page = entry.value;
+      return {
+        'id': page.id,
+        'material_id': materialId,
+        'page_order': index,
+        'title': page.pageTitle,
+        'objects': page.toJson(),
+      };
+    }).toList();
+
+    if (insertData.isNotEmpty) {
+      await _client.from('pages').insert(insertData);
+    }
+  }
 }


### PR DESCRIPTION
## 概要
イシュー #9 の複数ページ対応機能を実装しました。

## 変更内容
- BoardStateに複数ページ対応のpages、currentPageIndexを追加
- BoardNotifierにページ切り替え、追加、削除機能を実装
- BoardScreenに教師編集モード用のページタブバーUI追加
- MaterialsServiceにsaveAllPages機能を追加

## 機能
- ✅ ページ追加ボタンがある
- ✅ ページ一覧から切り替えができる
- ✅ 各ページが独立してSupabaseに保存される

Closes #9

🤖 Generated with [Claude Code](https://claude.ai/code)